### PR TITLE
Scale up storage capacity

### DIFF
--- a/cluster-autoscaler/FAQ.md
+++ b/cluster-autoscaler/FAQ.md
@@ -36,6 +36,7 @@ this document:
   * [How can I configure overprovisioning with Cluster Autoscaler?](#how-can-i-configure-overprovisioning-with-cluster-autoscaler)
   * [How can I enable/disable eviction for a specific DaemonSet](#how-can-i-enabledisable-eviction-for-a-specific-daemonset)
   * [How can I enable Cluster Autoscaler to scale up when Node's max volume count is exceeded (CSI migration enabled)?](#how-can-i-enable-cluster-autoscaler-to-scale-up-when-nodes-max-volume-count-is-exceeded-csi-migration-enabled)
+  * [How can I enable autoscaling for Pods with volumes?](#how-can-i-enable-autoscaling-for-pods-with-volumes)
 * [Internals](#internals)
   * [Are all of the mentioned heuristics and timings final?](#are-all-of-the-mentioned-heuristics-and-timings-final)
   * [How does scale-up work?](#how-does-scale-up-work)
@@ -494,6 +495,99 @@ For example:
 For a complete list of the feature gates and their default values per Kubernetes versions, refer to the [Feature Gates documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
 
 ****************
+
+### How can I enable autoscaling for Pods with volumes?
+
+For network-attached storage, autoscaling works as long as the storage system
+does not run out of space for new volumes. Cluster Autoscaler has no support
+for automatically increasing storage pools when that happens.
+
+For storage that is local to nodes the situation is different. Solutions
+depend on the specific scenario.
+
+#### Dynamic provisioning with immediate binding
+
+When volumes are provisioned dynamically through a storage class with immediate
+[binding](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode),
+then scheduling and thus the code in Cluster Autoscaler just waits for the
+volumes to be created. If that depends on creating new nodes, then scale up is
+not triggered. It's better to use the `WaitForFirstConsumer` binding mode.
+
+#### Dynamic provisioning with delayed binding
+
+When the binding mode is `WaitForFirstConsumer`, volume provisioning starts
+when the first Pod tries to use a PersistentVolumeClaim. The scheduler is
+involved in choosing a node candidate and then the provisioner tries to create
+the volume on that node.
+
+When the Cluster Autoscaler considers whether a Pod waiting for such a volume
+could run on a new node, the outcome depends on whether storage capacity
+tracking, a beta feature for CSI drivers since Kubernetes 1.21, is enabled or
+disabled. When disabled, the volume binder will assume that all nodes are
+suitable. This may cause the Cluster Autoscaler to create new nodes from a pool
+that doesn't actually have local storage.
+
+If it is enabled, then additional configuration of the Cluster Autoscaler is
+needed to inform it how much storage new nodes of a pool will have. This must
+be done for each CSI driver and each storage class of that driver. Suppose
+there is a `csi-lvm-fast` storage class for a fictional LVM CSI driver and a
+node pool where node names are `aks-workerpool-<unique id>`. The following
+command will create a CSIStorageCapacity object that states that new nodes
+will have a certain amount of free storage:
+
+```
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIStorageCapacity
+metadata:
+  # The name does not matter. It just has to be unique
+  # inside the namespace.
+  name: aks-workerpool-csi-lvm-fast-storage
+  # Other namespaces also work. As this object is owned by the
+  # cluster administrator, kube-system is a good choice.
+  namespace: kube-system
+# Capacity and maximumVolumeSize must be the same as what the CSI driver
+# will report for new nodes with unused storage.
+capacity: 100Gi
+maximumVolumeSize: 100Gi
+nodeTopology:
+  matchLabels:
+    # This never matches a real node, only the node templates
+    # inside Cluster Autoscaler.
+    topology.hostpath.csi/node: aks-workerpool-template
+storageClassName: csi-lvm-fast
+EOF
+```
+
+Now Cluster Autoscaler must be configured to change the node template labels
+such that the volume capacity check looks at that object instead of the one for
+the node from which the template was created. This is done with a command line
+flag that enables regular expression matching and replacement for labels,
+similar to `sed -e s/foo-.*/foo-template/`:
+
+```
+--replace-labels ';^topology.lvm.csi/node=aks-workerpool.*;topology.lvm.csi/node=aks-workerpool-template;'
+```
+
+`topology.lvm.csi/node` in this example is the label that gets added when the
+LVM CSI driver is registered on a node by kubelet. For local storage, the value
+of that label is usually the host name, which is what must be modified.
+
+For scaling up from zero, the `topology.lvm.csi/node=aks-workerpool-template`
+label must be added to the configuration for the node pool. How to do this
+depends on the cloud provider.
+
+TODO: describe how to avoid over-provisioning
+
+#### Static provisioning
+
+When using something like the [Local Persistence Volume Static
+Provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner),
+new PersistentVolumes are created when new nodes are added. Those
+PersistentVolumes then may be used to satisfy unbound volume claims that
+prevented Pods from running earlier.
+
+Cluster Autoscaler currently has no support for this scenario.
 
 # Internals
 

--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"time"
+
+	"k8s.io/autoscaler/cluster-autoscaler/utils/replace"
 )
 
 // GpuLimits define lower and upper bound on GPU instances of given type in cluster
@@ -151,6 +153,11 @@ type AutoscalingOptions struct {
 	MaxPodEvictionTime time.Duration
 	// IgnoredTaints is a list of taints to ignore when considering a node template for scheduling.
 	IgnoredTaints []string
+	// LabelReplacements is a list of regular expressions and their replacement that get applied
+	// to labels of existing nodes when creating node templates. The string that the regular
+	// expression is matched against is "<key>=<value>". If the value part is empty or missing
+	// after the transformation, the tag gets removed.
+	LabelReplacements replace.Replacements
 	// BalancingExtraIgnoredLabels is a list of labels to additionally ignore when comparing if two node groups are similar.
 	// Labels in BasicIgnoredLabels and the cloud provider-specific ignored labels are always ignored.
 	BalancingExtraIgnoredLabels []string

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 )
 
@@ -39,6 +40,7 @@ import (
 type AutoscalerOptions struct {
 	config.AutoscalingOptions
 	KubeClient             kube_client.Interface
+	InformerFactory        informers.SharedInformerFactory
 	EventsKubeClient       kube_client.Interface
 	AutoscalingKubeClients *context.AutoscalingKubeClients
 	CloudProvider          cloudprovider.CloudProvider
@@ -84,14 +86,13 @@ func NewAutoscaler(opts AutoscalerOptions) (Autoscaler, errors.AutoscalerError) 
 // Initialize default options if not provided.
 func initializeDefaultOptions(opts *AutoscalerOptions) error {
 	if opts.Processors == nil {
-		opts.Processors = ca_processors.DefaultProcessors()
+		opts.Processors = ca_processors.DefaultProcessors(opts.InformerFactory)
 	}
 	if opts.AutoscalingKubeClients == nil {
 		opts.AutoscalingKubeClients = context.NewAutoscalingKubeClients(opts.AutoscalingOptions, opts.KubeClient, opts.EventsKubeClient)
 	}
 	if opts.PredicateChecker == nil {
-		predicateCheckerStopChannel := make(chan struct{})
-		predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(opts.KubeClient, predicateCheckerStopChannel)
+		predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(opts.KubeClient, opts.InformerFactory)
 		if err != nil {
 			return err
 		}

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -321,7 +320,7 @@ func computeExpansionOption(context *context.AutoscalingContext, podEquivalenceG
 // false if it didn't and error if an error occurred. Assumes that all nodes in the cluster are
 // ready and in sync with instance groups.
 func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.AutoscalingProcessors, clusterStateRegistry *clusterstate.ClusterStateRegistry, unschedulablePods []*apiv1.Pod,
-	nodes []*apiv1.Node, daemonSets []*appsv1.DaemonSet, nodeInfos map[string]*schedulerframework.NodeInfo, ignoredTaints taints.TaintKeySet) (*status.ScaleUpStatus, errors.AutoscalerError) {
+	nodes []*apiv1.Node, daemonSets []*appsv1.DaemonSet, nodeInfos map[string]*schedulerframework.NodeInfo, nodeTransformation *utils.NodeTransformation) (*status.ScaleUpStatus, errors.AutoscalerError) {
 	// From now on we only care about unschedulable pods that were marked after the newest
 	// node became available for the scheduler.
 	if len(unschedulablePods) == 0 {
@@ -506,7 +505,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 
 			// If possible replace candidate node-info with node info based on crated node group. The latter
 			// one should be more in line with nodes which will be created by node group.
-			mainCreatedNodeInfo, err := utils.GetNodeInfoFromTemplate(createNodeGroupResult.MainCreatedNodeGroup, daemonSets, context.PredicateChecker, ignoredTaints)
+			mainCreatedNodeInfo, err := utils.GetNodeInfoFromTemplate(createNodeGroupResult.MainCreatedNodeGroup, daemonSets, context.PredicateChecker, nodeTransformation)
 			if err == nil {
 				nodeInfos[createNodeGroupResult.MainCreatedNodeGroup.Id()] = mainCreatedNodeInfo
 			} else {
@@ -520,7 +519,7 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 			}
 
 			for _, nodeGroup := range createNodeGroupResult.ExtraCreatedNodeGroups {
-				nodeInfo, err := utils.GetNodeInfoFromTemplate(nodeGroup, daemonSets, context.PredicateChecker, ignoredTaints)
+				nodeInfo, err := utils.GetNodeInfoFromTemplate(nodeGroup, daemonSets, context.PredicateChecker, nodeTransformation)
 
 				if err != nil {
 					klog.Warningf("Cannot build node info for newly created extra node group %v; balancing similar node groups will not work; err=%v", nodeGroup.Id(), err)

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -46,6 +46,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
@@ -69,11 +74,11 @@ func TestScaleUpOK(t *testing.T) {
 			{"n2", 1000, 1000, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 80, 0, 0, "n1", false},
-			{"p2", 800, 0, 0, "n2", false},
+			{"p1", 80, 0, 0, "n1", false, nil},
+			{"p2", 800, 0, 0, "n2", false, nil},
 		},
-		ExtraPods: []PodConfig{
-			{"p-new", 500, 0, 0, "", false},
+		DxtraPods: []PodConfig{
+			{"p-new", 500, 0, 0, "", false, nil},
 		},
 		Options:                 defaultOptions,
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng2", SizeChange: 1},
@@ -96,16 +101,16 @@ func TestMixedScaleUp(t *testing.T) {
 			{"n2", 1000, 100, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 80, 0, 0, "n1", false},
-			{"p2", 800, 0, 0, "n2", false},
+			{"p1", 80, 0, 0, "n1", false, nil},
+			{"p2", 800, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
 			// can only be scheduled on ng2
-			{"triggering", 900, 0, 0, "", false},
+			{"triggering", 900, 0, 0, "", false, nil},
 			// can't be scheduled
-			{"remaining", 2000, 0, 0, "", false},
+			{"remaining", 2000, 0, 0, "", false, nil},
 			// can only be scheduled on ng1
-			{"awaiting", 0, 200, 0, "", false},
+			{"awaiting", 0, 200, 0, "", false, nil},
 		},
 		Options:                 defaultOptions,
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng2", SizeChange: 1},
@@ -131,12 +136,12 @@ func TestScaleUpMaxCoresLimitHit(t *testing.T) {
 			{"n2", 4000, 1000, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 2000, 0, 0, "", false},
-			{"p-new-2", 2000, 0, 0, "", false},
+			{"p-new-1", 2000, 0, 0, "", false, nil},
+			{"p-new-2", 2000, 0, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng1", SizeChange: 2},
 		Options:                 options,
@@ -160,12 +165,12 @@ func TestScaleUpMaxCoresLimitHitWithNotAutoscaledGroup(t *testing.T) {
 			{"n2", 4000, 1000, 0, true, ""},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 2000, 0, 0, "", false},
-			{"p-new-2", 2000, 0, 0, "", false},
+			{"p-new-1", 2000, 0, 0, "", false, nil},
+			{"p-new-2", 2000, 0, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng1", SizeChange: 2},
 		Options:                 options,
@@ -189,13 +194,13 @@ func TestScaleUpMaxMemoryLimitHit(t *testing.T) {
 			{"n2", 4000, 1000 * utils.MiB, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 2000, 100 * utils.MiB, 0, "", false},
-			{"p-new-2", 2000, 100 * utils.MiB, 0, "", false},
-			{"p-new-3", 2000, 100 * utils.MiB, 0, "", false},
+			{"p-new-1", 2000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-2", 2000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-3", 2000, 100 * utils.MiB, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng1", SizeChange: 3},
 		Options:                 options,
@@ -219,13 +224,13 @@ func TestScaleUpMaxMemoryLimitHitWithNotAutoscaledGroup(t *testing.T) {
 			{"n2", 4000, 1000 * utils.MiB, 0, true, ""},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 2000, 100 * utils.MiB, 0, "", false},
-			{"p-new-2", 2000, 100 * utils.MiB, 0, "", false},
-			{"p-new-3", 2000, 100 * utils.MiB, 0, "", false},
+			{"p-new-1", 2000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-2", 2000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-3", 2000, 100 * utils.MiB, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng1", SizeChange: 3},
 		Options:                 options,
@@ -249,13 +254,13 @@ func TestScaleUpCapToMaxTotalNodesLimit(t *testing.T) {
 			{"n2", 4000, 1000 * utils.MiB, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 4000, 100 * utils.MiB, 0, "", false},
-			{"p-new-2", 4000, 100 * utils.MiB, 0, "", false},
-			{"p-new-3", 4000, 100 * utils.MiB, 0, "", false},
+			{"p-new-1", 4000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-2", 4000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-3", 4000, 100 * utils.MiB, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng2", SizeChange: 3},
 		Options:                 options,
@@ -279,13 +284,13 @@ func TestScaleUpCapToMaxTotalNodesLimitWithNotAutoscaledGroup(t *testing.T) {
 			{"n2", 4000, 1000 * utils.MiB, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 4000, 100 * utils.MiB, 0, "", false},
-			{"p-new-2", 4000, 100 * utils.MiB, 0, "", false},
-			{"p-new-3", 4000, 100 * utils.MiB, 0, "", false},
+			{"p-new-1", 4000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-2", 4000, 100 * utils.MiB, 0, "", false, nil},
+			{"p-new-3", 4000, 100 * utils.MiB, 0, "", false, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "ng2", SizeChange: 3},
 		Options:                 options,
@@ -309,11 +314,11 @@ func TestWillConsiderGpuAndStandardPoolForPodWhichDoesNotRequireGpu(t *testing.T
 			{"std-node-1", 2000, 1000 * utils.MiB, 0, true, "std-pool"},
 		},
 		Pods: []PodConfig{
-			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-node-1", true},
-			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false},
+			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-node-1", true, nil},
+			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"extra-std-pod", 2000, 1000 * utils.MiB, 0, "", true},
+			{"extra-std-pod", 2000, 1000 * utils.MiB, 0, "", true, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "std-pool", SizeChange: 1},
 		Options:                 options,
@@ -341,11 +346,11 @@ func TestWillConsiderOnlyGpuPoolForPodWhichDoesRequiresGpu(t *testing.T) {
 			{"std-node-1", 2000, 1000 * utils.MiB, 0, true, "std-pool"},
 		},
 		Pods: []PodConfig{
-			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-node-1", true},
-			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false},
+			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-node-1", true, nil},
+			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"extra-gpu-pod", 2000, 1000 * utils.MiB, 1, "", true},
+			{"extra-gpu-pod", 2000, 1000 * utils.MiB, 1, "", true, nil},
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "gpu-pool", SizeChange: 1},
 		Options:                 options,
@@ -374,15 +379,15 @@ func TestWillConsiderAllPoolsWhichFitTwoPodsRequiringGpus(t *testing.T) {
 			{"std-node-1", 2000, 1000 * utils.MiB, 0, true, "std-pool"},
 		},
 		Pods: []PodConfig{
-			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-1-node-1", true},
-			{"gpu-pod-2", 2000, 1000 * utils.MiB, 2, "gpu-2-node-1", true},
-			{"gpu-pod-3", 2000, 1000 * utils.MiB, 4, "gpu-4-node-1", true},
-			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false},
+			{"gpu-pod-1", 2000, 1000 * utils.MiB, 1, "gpu-1-node-1", true, nil},
+			{"gpu-pod-2", 2000, 1000 * utils.MiB, 2, "gpu-2-node-1", true, nil},
+			{"gpu-pod-3", 2000, 1000 * utils.MiB, 4, "gpu-4-node-1", true, nil},
+			{"std-pod-1", 2000, 1000 * utils.MiB, 0, "std-node-1", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"extra-gpu-pod-1", 1, 1 * utils.MiB, 1, "", true}, // CPU and mem negligible
-			{"extra-gpu-pod-2", 1, 1 * utils.MiB, 1, "", true}, // CPU and mem negligible
-			{"extra-gpu-pod-3", 1, 1 * utils.MiB, 1, "", true}, // CPU and mem negligible
+			{"extra-gpu-pod-1", 1, 1 * utils.MiB, 1, "", true, nil}, // CPU and mem negligible
+			{"extra-gpu-pod-2", 1, 1 * utils.MiB, 1, "", true, nil}, // CPU and mem negligible
+			{"extra-gpu-pod-3", 1, 1 * utils.MiB, 1, "", true, nil}, // CPU and mem negligible
 		},
 		ExpansionOptionToChoose: GroupSizeChange{GroupName: "gpu-1-pool", SizeChange: 3},
 		Options:                 options,
@@ -413,12 +418,12 @@ func TestNoScaleUpMaxCoresLimitHit(t *testing.T) {
 			{"n2", 4000, 1000, 0, true, "ng2"},
 		},
 		Pods: []PodConfig{
-			{"p1", 1000, 0, 0, "n1", false},
-			{"p2", 3000, 0, 0, "n2", false},
+			{"p1", 1000, 0, 0, "n1", false, nil},
+			{"p2", 3000, 0, 0, "n2", false, nil},
 		},
 		ExtraPods: []PodConfig{
-			{"p-new-1", 2000, 0, 0, "", false},
-			{"p-new-2", 2000, 0, 0, "", false},
+			{"p-new-1", 2000, 0, 0, "", false, nil},
+			{"p-new-2", 2000, 0, 0, "", false, nil},
 		},
 		Options: options,
 	}
@@ -496,6 +501,24 @@ func runSimpleScaleUpTest(t *testing.T, config *ScaleTestConfig) *ScaleTestResul
 	for _, p := range config.Pods {
 		pod := buildTestPod(p)
 		pods = append(pods, pod)
+	}
+
+	var objs []runtime.Object
+	for _, p := range config.Pvcs {
+		pvc := buildTestPVC(p)
+		objs = append(objs, pvc)
+	}
+	for _, s := range config.Scs {
+		sc := buildTestSC(s)
+		objs = append(objs, sc)
+	}
+	for _, csi := range config.Csi {
+		c := buildTestCSIDriver(csi)
+		objs = append(objs, c)
+	}
+	for _, cap := range config.Cap {
+		c := buildTestCSIStorageCapacity(cap)
+		objs = append(objs, c)
 	}
 
 	podLister := kube_util.NewTestPodLister(pods)
@@ -656,7 +679,78 @@ func buildTestPod(p PodConfig) *apiv1.Pod {
 	if p.Node != "" {
 		pod.Spec.NodeName = p.Node
 	}
+	for _, pvc := range p.Pvcs {
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, apiv1.VolumeMount{
+			Name:      pvc,
+			MountPath: "/" + pvc,
+		})
+		pod.Spec.Volumes = append(pod.Spec.Volumes, apiv1.Volume{
+			Name: pvc,
+			VolumeSource: apiv1.VolumeSource{
+				PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvc,
+				},
+			},
+		})
+	}
 	return pod
+}
+
+func buildTestPVC(p pvcConfig) *apiv1.PersistentVolumeClaim {
+	pvc := &apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.name,
+			Namespace: "default",
+		},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			Resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceStorage: resource.MustParse(p.size),
+				},
+			},
+			StorageClassName: &p.storageclass,
+		},
+	}
+	return pvc
+}
+
+func buildTestSC(s scConfig) *storagev1.StorageClass {
+	mode := storagev1.VolumeBindingWaitForFirstConsumer
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.name,
+		},
+		Provisioner:       s.provisioner,
+		VolumeBindingMode: &mode,
+	}
+	return sc
+}
+
+func buildTestCSIDriver(c csiDriverConfig) *storagev1.CSIDriver {
+	csi := &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+		Spec: storagev1.CSIDriverSpec{
+			StorageCapacity: &c.storageCapacity,
+		},
+	}
+	return csi
+}
+
+func buildTestCSIStorageCapacity(c csiStorageCapacityConfig) *storagev1beta1.CSIStorageCapacity {
+	quantity := resource.MustParse(c.capacity)
+	csi := &storagev1beta1.CSIStorageCapacity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+		StorageClassName: c.storageClass,
+		NodeTopology: &metav1.LabelSelector{
+			MatchLabels: c.nodeLabels,
+		},
+		Capacity: &quantity,
+	}
+	return csi
 }
 
 func TestScaleUpUnhealthy(t *testing.T) {
@@ -1018,15 +1112,107 @@ func TestAuthError(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "cluster_autoscaler_failed_scale_ups_total{reason=\"abcd\"} 1")
 }
 
-func simplifyScaleUpStatus(scaleUpStatus *status.ScaleUpStatus) ScaleUpStatusInfo {
-	remainUnschedulable := []string{}
-	for _, nsi := range scaleUpStatus.PodsRemainUnschedulable {
-		remainUnschedulable = append(remainUnschedulable, nsi.Pod.Name)
+func TestScaleUpLateBinding(t *testing.T) {
+	// A pod using an unbound PVC with late binding can be scheduled, so
+	// a cluster will get scaled up.
+	config := &scaleTestConfig{
+		nodes: []nodeConfig{
+			{"n1", 100, 100, 0, true, "ng1"},
+			{"n2", 1000, 1000, 0, true, "ng2"},
+		},
+		ExtraPods: []PodConfig{
+			{"p-new", 500, 0, 0, "", false, []string{"pvc1"}},
+		},
+		pvcs: []pvcConfig{
+			{"pvc1", "1Gi", "lvm-storage-class"},
+		},
+		scs: []scConfig{
+			{"lvm-storage-class", "lvm.example.com"},
+		},
+		Options:                 defaultOptions,
+		expansionOptionToChoose: groupSizeChange{groupName: "ng2", sizeChange: 1},
 	}
-	return ScaleUpStatusInfo{
-		Result:                  scaleUpStatus.Result,
-		PodsTriggeredScaleUp:    ExtractPodNames(scaleUpStatus.PodsTriggeredScaleUp),
-		PodsRemainUnschedulable: remainUnschedulable,
-		PodsAwaitEvaluation:     ExtractPodNames(scaleUpStatus.PodsAwaitEvaluation),
+	expectedResults := &scaleTestResults{
+		finalOption: groupSizeChange{groupName: "ng2", sizeChange: 1},
+		scaleUpStatus: scaleUpStatusInfo{
+			podsTriggeredScaleUp: []string{"p-new"},
+		},
 	}
+
+	simpleScaleUpTest(t, config, expectedResults)
+}
+
+func TestScaleUpNoStorage(t *testing.T) {
+	// When storage capacity tracking is enabled, a pod using an
+	// unbound PVC with late binding can be scheduled only if the
+	// node candidates are known to have capacity available, which
+	// isn't the case here.
+	config := &scaleTestConfig{
+		nodes: []nodeConfig{
+			{"n1", 100, 100, 0, true, "ng1"},
+			{"n2", 1000, 1000, 0, true, "ng2"},
+		},
+		ExtraPods: []PodConfig{
+			{"p-new", 500, 0, 0, "", false, []string{"pvc1"}},
+		},
+		pvcs: []pvcConfig{
+			{"pvc1", "1Gi", "lvm-storage-class"},
+		},
+		scs: []scConfig{
+			{"lvm-storage-class", "lvm.example.com"},
+		},
+		csi: []csiDriverConfig{
+			{"lvm.example.com", true},
+		},
+		Options:                 defaultOptions,
+		expansionOptionToChoose: groupSizeChange{groupName: "ng2", sizeChange: 1},
+	}
+	expectedResults := &scaleTestResults{
+		finalOption: groupSizeChange{},
+		scaleUpStatus: scaleUpStatusInfo{
+			podsRemainUnschedulable: []string{"p-new"},
+		},
+	}
+
+	simpleNoScaleUpTest(t, config, expectedResults)
+}
+
+func TestScaleUpEnoughStorage(t *testing.T) {
+	// When storage capacity tracking is enabled, a pod using an
+	// unbound PVC with late binding can be scheduled only if the
+	// node candidates are known to have capacity available.
+	// This can be configured for node candidates by giving them
+	// special labels (TODO: how?) and then manually creating
+	// CSIStorageCapacity objects for them.
+	config := &scaleTestConfig{
+		nodes: []nodeConfig{
+			{"n1", 100, 100, 0, true, "ng1"},
+			{"n2", 1000, 1000, 0, true, "ng2"},
+		},
+		ExtraPods: []PodConfig{
+			{"p-new", 500, 0, 0, "", false, []string{"pvc1"}},
+		},
+		pvcs: []pvcConfig{
+			{"pvc1", "1Gi", "lvm-storage-class"},
+		},
+		scs: []scConfig{
+			{"lvm-storage-class", "lvm.example.com"},
+		},
+		csi: []csiDriverConfig{
+			{"lvm.example.com", true},
+		},
+		cap: []csiStorageCapacityConfig{
+			{"abc", "lvm-storage-class", nil /* TODO: node labels */, "1Ti"},
+		},
+		Options:                 defaultOptions,
+		expansionOptionToChoose: groupSizeChange{groupName: "ng2", sizeChange: 1},
+	}
+	expectedResults := &scaleTestResults{
+		finalOption: groupSizeChange{groupName: "ng2", sizeChange: 1},
+		scaleUpStatus: scaleUpStatusInfo{
+			podsTriggeredScaleUp: []string{"p-new"},
+		},
+	}
+
+	simpleScaleUpTest(t, config, expectedResults)
 }

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodeinfosprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
@@ -77,7 +76,7 @@ func TestScaleUpOK(t *testing.T) {
 			{"p1", 80, 0, 0, "n1", false, nil},
 			{"p2", 800, 0, 0, "n2", false, nil},
 		},
-		DxtraPods: []PodConfig{
+		ExtraPods: []PodConfig{
 			{"p-new", 500, 0, 0, "", false, nil},
 		},
 		Options:                 defaultOptions,

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -1182,8 +1182,8 @@ func TestScaleUpEnoughStorage(t *testing.T) {
 	// unbound PVC with late binding can be scheduled only if the
 	// node candidates are known to have capacity available.
 	// This can be configured for node candidates by giving them
-	// special labels (TODO: how?) and then manually creating
-	// CSIStorageCapacity objects for them.
+	// special labels (via regex replace and/or labels on the node pool)
+	// and then manually creating CSIStorageCapacity objects for them.
 	config := &scaleTestConfig{
 		nodes: []nodeConfig{
 			{"n1", 100, 100, 0, true, "ng1"},

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -47,7 +47,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -738,9 +737,9 @@ func buildTestCSIDriver(c CsiDriverConfig) *storagev1.CSIDriver {
 	return csi
 }
 
-func buildTestCSIStorageCapacity(c CsiStorageCapacityConfig) *storagev1beta1.CSIStorageCapacity {
+func buildTestCSIStorageCapacity(c CsiStorageCapacityConfig) *storagev1.CSIStorageCapacity {
 	quantity := resource.MustParse(c.Capacity)
-	csi := &storagev1beta1.CSIStorageCapacity{
+	csi := &storagev1.CSIStorageCapacity{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.Name,
 		},

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -771,6 +771,12 @@ func (a *StaticAutoscaler) obtainNodeLists(cp cloudprovider.CloudProvider) ([]*a
 	// TODO: Remove this call when we handle dynamically provisioned resources.
 	allNodes, readyNodes = a.processors.CustomResourcesProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
 	allNodes, readyNodes = taints.FilterOutNodesWithIgnoredTaints(a.nodeTransformation.IgnoredTaints, allNodes, readyNodes)
+
+	// Filter out nodes that aren't ready because of a missing CSI driver.
+	if a.processors.CSIProcessor != nil {
+		allNodes, readyNodes = a.processors.CSIProcessor.FilterOutNodesWithUnreadyResources(a.AutoscalingContext, allNodes, readyNodes)
+	}
+
 	return allNodes, readyNodes, nil
 }
 

--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/deletiontracker"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/legacy"
 	core_utils "k8s.io/autoscaler/cluster-autoscaler/core/utils"
-	coreutils "k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
 	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
@@ -79,7 +78,7 @@ type StaticAutoscaler struct {
 	processors              *ca_processors.AutoscalingProcessors
 	processorCallbacks      *staticAutoscalerProcessorCallbacks
 	initialized             bool
-	nodeTransformation      coreutils.NodeTransformation
+	nodeTransformation      core_utils.NodeTransformation
 }
 
 type staticAutoscalerProcessorCallbacks struct {
@@ -174,7 +173,7 @@ func NewStaticAutoscaler(
 		processors:              processors,
 		processorCallbacks:      processorCallbacks,
 		clusterStateRegistry:    clusterStateRegistry,
-		nodeTransformation: coreutils.NodeTransformation{
+		nodeTransformation: core_utils.NodeTransformation{
 			IgnoredTaints:     ignoredTaints,
 			LabelReplacements: opts.LabelReplacements,
 		},

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -98,7 +98,7 @@ type CsiDriverConfig struct {
 }
 
 type CsiStorageCapacityConfig struct {
-	Mame         string
+	Name         string
 	StorageClass string
 	NodeLabels   map[string]string
 	Capacity     string

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -194,7 +194,7 @@ func NewScaleTestAutoscalingContext(
 	// Ignoring error here is safe - if a test doesn't specify valid estimatorName,
 	// it either doesn't need one, or should fail when it turns out to be nil.
 	estimatorBuilder, _ := estimator.NewEstimatorBuilder(options.EstimatorName, estimator.NewThresholdBasedEstimationLimiter(0, 0))
-	predicateChecker, err := simulator.NewTestPredicateChecker()
+	predicateChecker, err := simulator.NewSchedulerBasedPredicateChecker(fakeClient, nil)
 	if err != nil {
 		return context.AutoscalingContext{}, err
 	}

--- a/cluster-autoscaler/core/test/common.go
+++ b/cluster-autoscaler/core/test/common.go
@@ -78,6 +78,30 @@ type PodConfig struct {
 	Gpu          int64
 	Node         string
 	ToleratesGpu bool
+	Pvcs         []string
+}
+
+type PvcConfig struct {
+	Name         string
+	Size         string // must parse as a resource.Quantity
+	Storageclass string
+}
+
+type ScConfig struct {
+	Name        string
+	Provisioner string
+}
+
+type CsiDriverConfig struct {
+	Name            string
+	StorageCapacity bool
+}
+
+type CsiStorageCapacityConfig struct {
+	Mame         string
+	StorageClass string
+	NodeLabels   map[string]string
+	Capacity     string
 }
 
 // GroupSizeChange represents a change in group size
@@ -94,6 +118,10 @@ type ScaleTestConfig struct {
 	Options                 config.AutoscalingOptions
 	NodeDeletionTracker     *deletiontracker.NodeDeletionTracker
 	ExpansionOptionToChoose GroupSizeChange // this will be selected by assertingStrategy.BestOption
+	Pvcs                    []PvcConfig
+	Scs                     []ScConfig
+	Csi                     []CsiDriverConfig
+	Cap                     []CsiStorageCapacityConfig
 
 	ExpectedScaleDowns     []string
 	ExpectedScaleDownCount int

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -390,8 +390,6 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 		}
 		nodeInfoComparator = nodeInfoComparatorBuilder(autoscalingOptions.BalancingExtraIgnoredLabels)
 	}
-		nodeInfoComparator = nodeInfoComparatorBuilder(autoscalingOptions.BalancingExtraIgnoredLabels)
-	}
 
 	opts.Processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
 		Comparator: nodeInfoComparator,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/replace"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
 	kube_client "k8s.io/client-go/kubernetes"
@@ -178,7 +179,13 @@ var (
 	regional                      = flag.Bool("regional", false, "Cluster is regional.")
 	newPodScaleUpDelay            = flag.Duration("new-pod-scale-up-delay", 0*time.Second, "Pods less than this old will not be considered for scale-up.")
 
-	ignoreTaintsFlag                   = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	ignoreTaintsFlag  = multiStringFlag("ignore-taint", "Specifies a taint to ignore in node templates when considering to scale a node group")
+	labelReplacements = func() *replace.Replacements {
+		repl := &replace.Replacements{}
+		flag.Var(repl, "replace-labels", "Specifies one or more regular expression replacements of the form ;<regexp>;<replacement>; (any other character as separator also allowed) which get applied one after the other to labels of a node to form a template node. Labels are represented as a single string with <key>=<value>. If the key is empty after replacement, the label gets removed.")
+		return repl
+	}()
+
 	balancingIgnoreLabelsFlag          = multiStringFlag("balancing-ignore-label", "Specifies a label to ignore in addition to the basic and cloud-provider set of labels when comparing if two node groups are similar")
 	balancingLabelsFlag                = multiStringFlag("balancing-label", "Specifies a label to use for comparing if two node groups are similar, rather than the built in heuristics. Setting this flag disables all other comparison logic, and cannot be combined with --balancing-ignore-label.")
 	awsUseStaticInstanceList           = flag.Bool("aws-use-static-instance-list", false, "Should CA fetch instance types in runtime or use a static list. AWS only")
@@ -275,6 +282,7 @@ func createAutoscalingOptions() config.AutoscalingOptions {
 		Regional:                           *regional,
 		NewPodScaleUpDelay:                 *newPodScaleUpDelay,
 		IgnoredTaints:                      *ignoreTaintsFlag,
+		LabelReplacements:                  *labelReplacements,
 		BalancingExtraIgnoredLabels:        *balancingIgnoreLabelsFlag,
 		BalancingLabels:                    *balancingLabelsFlag,
 		KubeConfigPath:                     *kubeConfigFile,

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/replace"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/autoscaler/cluster-autoscaler/version"
+	"k8s.io/client-go/informers"
 	kube_client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -353,16 +354,22 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	autoscalingOptions := createAutoscalingOptions()
 	kubeClient := createKubeClient(getKubeConfig())
 	eventsKubeClient := createKubeClient(getKubeConfig())
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+
+	// This isn't particularly useful at the moment. Perhaps we can accept
+	// a context and then our caller can decide about a suitable deadline.
+	stopChannel := make(chan struct{})
 
 	opts := core.AutoscalerOptions{
 		AutoscalingOptions:   autoscalingOptions,
 		ClusterSnapshot:      simulator.NewDeltaClusterSnapshot(),
 		KubeClient:           kubeClient,
+		InformerFactory:      informerFactory,
 		EventsKubeClient:     eventsKubeClient,
 		DebuggingSnapshotter: debuggingSnapshotter,
 	}
 
-	opts.Processors = ca_processors.DefaultProcessors()
+	opts.Processors = ca_processors.DefaultProcessors(informerFactory)
 	opts.Processors.TemplateNodeInfoProvider = nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nodeInfoCacheExpireTime)
 	opts.Processors.PodListProcessor = filteroutschedulable.NewFilterOutSchedulablePodListProcessor()
 
@@ -383,6 +390,8 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 		}
 		nodeInfoComparator = nodeInfoComparatorBuilder(autoscalingOptions.BalancingExtraIgnoredLabels)
 	}
+		nodeInfoComparator = nodeInfoComparatorBuilder(autoscalingOptions.BalancingExtraIgnoredLabels)
+	}
 
 	opts.Processors.NodeGroupSetProcessor = &nodegroupset.BalancingNodeGroupSetProcessor{
 		Comparator: nodeInfoComparator,
@@ -395,7 +404,27 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	metrics.UpdateMemoryLimitsBytes(autoscalingOptions.MinMemoryTotal, autoscalingOptions.MaxMemoryTotal)
 
 	// Create autoscaler.
-	return core.NewAutoscaler(opts)
+	autoscaler, err := core.NewAutoscaler(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// this MUST be called after all the informers/listers are acquired via the
+	// informerFactory....Lister()/informerFactory....Informer() methods
+	informerFactory.Start(stopChannel)
+
+	// Also wait for all informers to be up-to-date. This is necessary for
+	// objects that were added when creating the fake client. Without
+	// this wait, those objects won't be visible via the informers when
+	// the test runs.
+	synced := informerFactory.WaitForCacheSync(stopChannel)
+	for k, v := range synced {
+		if !v {
+			return nil, fmt.Errorf("failed to sync informer %v", k)
+		}
+	}
+
+	return autoscaler, err
 }
 
 func run(healthCheck *metrics.HealthCheck, debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter) {

--- a/cluster-autoscaler/processors/csi/csi_processor.go
+++ b/cluster-autoscaler/processors/csi/csi_processor.go
@@ -33,13 +33,14 @@ import (
 // configured to check storage capacity.
 //
 // Without this processor, the following happens:
-// - autoscaler determines that it needs a new node to get volumes
-//   for a pending pod created
-// - the new node starts and is ready to run pods, but the CSI driver
-//   itself hasn't started running on it yet
-// - autoscaler checks for pending pods, finds that the pod still
-//   cannot run and asks for another node
-// - the CSI driver starts, creates volumes and the pod runs
+//   - autoscaler determines that it needs a new node to get volumes
+//     for a pending pod created
+//   - the new node starts and is ready to run pods, but the CSI driver
+//     itself hasn't started running on it yet
+//   - autoscaler checks for pending pods, finds that the pod still
+//     cannot run and asks for another node
+//   - the CSI driver starts, creates volumes and the pod runs
+//
 // => the extra node is redundant
 //
 // To determine whether a node will have a CSI driver, a heuristic is used: if
@@ -75,7 +76,7 @@ func (p csiProcessor) FilterOutNodesWithUnreadyResources(context *context.Autosc
 		if p.isReady(context, node) {
 			newReadyNodes = append(newReadyNodes, node)
 		} else {
-			nodesWithUnreadyCSI[node.Name] = kubernetes.GetUnreadyNodeCopy(node)
+			nodesWithUnreadyCSI[node.Name] = kubernetes.GetUnreadyNodeCopy(node, "csi not ready")
 		}
 	}
 	// Override any node with unready CSI with its "unready" copy

--- a/cluster-autoscaler/processors/csi/csi_processor.go
+++ b/cluster-autoscaler/processors/csi/csi_processor.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
+	"k8s.io/client-go/informers"
+	storagev1beta1listers "k8s.io/client-go/listers/storage/v1beta1"
+	"k8s.io/klog/v2"
+)
+
+// CSIProcessor checks whether a node is ready for applications using volumes
+// provided by a CSI driver. This is relevant when the autoscaler has been
+// configured to check storage capacity.
+//
+// Without this processor, the following happens:
+// - autoscaler determines that it needs a new node to get volumes
+//   for a pending pod created
+// - the new node starts and is ready to run pods, but the CSI driver
+//   itself hasn't started running on it yet
+// - autoscaler checks for pending pods, finds that the pod still
+//   cannot run and asks for another node
+// - the CSI driver starts, creates volumes and the pod runs
+// => the extra node is redundant
+//
+// To determine whether a node will have a CSI driver, a heuristic is used: if
+// a template node derived from the node has a CSIStorageCapacity object, then
+// the node itself should also have one, otherwise it is not ready.
+type CSIProcessor interface {
+	// FilterOutNodesWithUnreadyResources removes nodes that should have a CSI
+	// driver, but don't have CSIStorageCapacity information yet.
+	FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node)
+
+	// CleanUp frees resources.
+	CleanUp()
+}
+
+type csiProcessor struct {
+	csiStorageCapacityLister storagev1beta1listers.CSIStorageCapacityLister
+}
+
+// FilterOutNodesWithUnreadyResources removes nodes that should have a CSI
+// driver, but don't have CSIStorageCapacity information yet.
+func (p csiProcessor) FilterOutNodesWithUnreadyResources(context *context.AutoscalingContext, allNodes, readyNodes []*apiv1.Node) ([]*apiv1.Node, []*apiv1.Node) {
+	newAllNodes := make([]*apiv1.Node, 0, len(allNodes))
+	newReadyNodes := make([]*apiv1.Node, 0, len(readyNodes))
+	nodesWithUnreadyCSI := make(map[string]*apiv1.Node)
+	for _, node := range readyNodes {
+		// TODO: short-circuit this check if the node has been in the
+		// ready state long enough? If all of the tests below hit the
+		// API server to query CSIDriver and CSIStorageCapacity objects
+		// and all nodes in a cluster get checked again during each
+		// scale up run, then this might create a lot of additional
+		// load.
+		klog.V(3).Infof("checking CSIStorageCapacity of node %s", node.Name)
+		if p.isReady(context, node) {
+			newReadyNodes = append(newReadyNodes, node)
+		} else {
+			nodesWithUnreadyCSI[node.Name] = kubernetes.GetUnreadyNodeCopy(node)
+		}
+	}
+	// Override any node with unready CSI with its "unready" copy
+	for _, node := range allNodes {
+		if newNode, found := nodesWithUnreadyCSI[node.Name]; found {
+			newAllNodes = append(newAllNodes, newNode)
+		} else {
+			newAllNodes = append(newAllNodes, node)
+		}
+	}
+	return newAllNodes, newReadyNodes
+}
+
+func (p csiProcessor) isReady(context *context.AutoscalingContext, node *v1.Node) bool {
+	cloudProvider := context.CloudProvider
+	nodeGroup, err := cloudProvider.NodeGroupForNode(node)
+	if err != nil || nodeGroup == nil {
+		// Not a node that is part of a node group? Assume that the normal
+		// ready state applies and continue.
+		klog.V(3).Infof("node %s has no node group, skip CSI check (error: %v)", node.Name, err)
+		return true
+	}
+	nodeInfo, err := nodeGroup.TemplateNodeInfo()
+	if err != nil {
+		// Again, ignore the node.
+		klog.V(3).Infof("node %s has no node info, skip CSI check: %v", node.Name, err)
+		return true
+	}
+	templateNode := nodeInfo.Node()
+	expected := p.numStorageCapacityObjects(templateNode)
+	if expected == 0 {
+		// Node cannot be unready because no CSI storage is expected.
+		klog.V(3).Infof("node %s is not expected to have CSI storage: %v", node.Name)
+		return true
+	}
+	actual := p.numStorageCapacityObjects(node)
+	if expected <= actual {
+		klog.V(3).Infof("node %s has enough CSIStorageCapacity objects (expected %d, have %d)",
+			node.Name, expected, actual)
+		return true
+	}
+
+	// CSI driver should have published capacity information and
+	// hasn't done it yet -> treat the node as not ready yet.
+	klog.V(3).Infof("node %s is expected to have %d CSIStorageCapacity objects, only has %d -> treat it as unready",
+		node.Name, expected, actual)
+	return false
+}
+
+func (p csiProcessor) numStorageCapacityObjects(node *v1.Node) int {
+	count := 0
+	capacities, err := p.csiStorageCapacityLister.List(labels.Everything())
+	if err != nil {
+		klog.Error(err, "list CSIStorageCapacity")
+		return 0
+	}
+	for _, capacity := range capacities {
+		// match labels
+		if capacity.NodeTopology == nil {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(capacity.NodeTopology)
+		if err != nil {
+			// Invalid capacity object? Ignore it.
+			continue
+		}
+		if selector.Matches(labels.Set(node.Labels)) {
+			count++
+		}
+	}
+	return count
+}
+
+func (p csiProcessor) CleanUp() {}
+
+// NewDefaultCSIProcessor returns a default instance of CSIProcessor.
+func NewDefaultCSIProcessor(informerFactory informers.SharedInformerFactory) CSIProcessor {
+	return csiProcessor{
+		csiStorageCapacityLister: informerFactory.Storage().V1beta1().CSIStorageCapacities().Lister(),
+	}
+}

--- a/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/annotation_node_info_provider.go
@@ -17,13 +17,13 @@ limitations under the License.
 package nodeinfosprovider
 
 import (
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
@@ -40,8 +40,8 @@ func NewAnnotationNodeInfoProvider(t *time.Duration) *AnnotationNodeInfoProvider
 }
 
 // Process returns the nodeInfos set for this cluster.
-func (p *AnnotationNodeInfoProvider) Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
-	nodeInfos, err := p.mixedTemplateNodeInfoProvider.Process(ctx, nodes, daemonsets, ignoredTaints, currentTime)
+func (p *AnnotationNodeInfoProvider) Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, nodeTransformation *utils.NodeTransformation, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
+	nodeInfos, err := p.mixedTemplateNodeInfoProvider.Process(ctx, nodes, daemonsets, nodeTransformation, currentTime)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/mixed_nodeinfos_processor.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/simulator"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	klog "k8s.io/klog/v2"
@@ -70,7 +69,7 @@ func (p *MixedTemplateNodeInfoProvider) CleanUp() {
 }
 
 // Process returns the nodeInfos set for this cluster
-func (p *MixedTemplateNodeInfoProvider) Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet, now time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
+func (p *MixedTemplateNodeInfoProvider) Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, nodeTransformation *utils.NodeTransformation, now time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError) {
 	// TODO(mwielgus): This returns map keyed by url, while most code (including scheduler) uses node.Name for a key.
 	// TODO(mwielgus): Review error policy - sometimes we may continue with partial errors.
 	result := make(map[string]*schedulerframework.NodeInfo)
@@ -97,7 +96,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx *context.AutoscalingContext,
 			if err != nil {
 				return false, "", err
 			}
-			sanitizedNodeInfo, err := utils.SanitizeNodeInfo(nodeInfo, id, ignoredTaints)
+			sanitizedNodeInfo, err := utils.SanitizeNodeInfo(nodeInfo, id, nodeTransformation)
 			if err != nil {
 				return false, "", err
 			}
@@ -143,7 +142,7 @@ func (p *MixedTemplateNodeInfoProvider) Process(ctx *context.AutoscalingContext,
 
 		// No good template, trying to generate one. This is called only if there are no
 		// working nodes in the node groups. By default CA tries to use a real-world example.
-		nodeInfo, err := utils.GetNodeInfoFromTemplate(nodeGroup, daemonsets, ctx.PredicateChecker, ignoredTaints)
+		nodeInfo, err := utils.GetNodeInfoFromTemplate(nodeGroup, daemonsets, ctx.PredicateChecker, nodeTransformation)
 		if err != nil {
 			if err == cloudprovider.ErrNotImplemented {
 				continue

--- a/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
+++ b/cluster-autoscaler/processors/nodeinfosprovider/node_info_provider_processor.go
@@ -23,15 +23,15 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/utils"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 // TemplateNodeInfoProvider is provides the initial nodeInfos set.
 type TemplateNodeInfoProvider interface {
 	// Process returns a map of nodeInfos for node groups.
-	Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, ignoredTaints taints.TaintKeySet, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError)
+	Process(ctx *context.AutoscalingContext, nodes []*apiv1.Node, daemonsets []*appsv1.DaemonSet, nodeTransformation *utils.NodeTransformation, currentTime time.Time) (map[string]*schedulerframework.NodeInfo, errors.AutoscalerError)
 	// CleanUp cleans up processor's internal structures.
 	CleanUp()
 }

--- a/cluster-autoscaler/processors/processors.go
+++ b/cluster-autoscaler/processors/processors.go
@@ -18,6 +18,7 @@ package processors
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/actionablecluster"
+	"k8s.io/autoscaler/cluster-autoscaler/processors/csi"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/customresources"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupconfig"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/pods"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/status"
+	"k8s.io/client-go/informers"
 )
 
 // AutoscalingProcessors are a set of customizable processors used for encapsulating
@@ -60,10 +62,12 @@ type AutoscalingProcessors struct {
 	CustomResourcesProcessor customresources.CustomResourcesProcessor
 	// ActionableClusterProcessor is interface defining whether the cluster is in an actionable state
 	ActionableClusterProcessor actionablecluster.ActionableClusterProcessor
+	// CSIProcessor checks for nodes that are not ready because the CSI driver is still starting up.
+	CSIProcessor csi.CSIProcessor
 }
 
 // DefaultProcessors returns default set of processors.
-func DefaultProcessors() *AutoscalingProcessors {
+func DefaultProcessors(informerFactory informers.SharedInformerFactory) *AutoscalingProcessors {
 	return &AutoscalingProcessors{
 		PodListProcessor:           pods.NewDefaultPodListProcessor(),
 		NodeGroupListProcessor:     nodegroups.NewDefaultNodeGroupListProcessor(),
@@ -77,6 +81,7 @@ func DefaultProcessors() *AutoscalingProcessors {
 		NodeInfoProcessor:          nodeinfos.NewDefaultNodeInfoProcessor(),
 		NodeGroupConfigProcessor:   nodegroupconfig.NewDefaultNodeGroupConfigProcessor(),
 		CustomResourcesProcessor:   customresources.NewDefaultCustomResourcesProcessor(),
+		CSIProcessor:               csi.NewDefaultCSIProcessor(informerFactory),
 		ActionableClusterProcessor: actionablecluster.NewDefaultActionableClusterProcessor(),
 		TemplateNodeInfoProvider:   nodeinfosprovider.NewDefaultTemplateNodeInfoProvider(nil),
 	}
@@ -96,6 +101,7 @@ func (ap *AutoscalingProcessors) CleanUp() {
 	ap.NodeInfoProcessor.CleanUp()
 	ap.NodeGroupConfigProcessor.CleanUp()
 	ap.CustomResourcesProcessor.CleanUp()
+	ap.CSIProcessor.CleanUp()
 	ap.TemplateNodeInfoProvider.CleanUp()
 	ap.ActionableClusterProcessor.CleanUp()
 }

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -42,8 +42,15 @@ type SchedulerBasedPredicateChecker struct {
 }
 
 // NewSchedulerBasedPredicateChecker builds scheduler based PredicateChecker.
-func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-chan struct{}) (*SchedulerBasedPredicateChecker, error) {
-	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+// The informer factory is optional. If nil, then this function will create one,
+// start it and wait for cache syncing.
+func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, informerFactory informers.SharedInformerFactory) (*SchedulerBasedPredicateChecker, error) {
+	startInformer := false
+	if informerFactory == nil {
+		informerFactory = informers.NewSharedInformerFactory(kubeClient, 0)
+		startInformer = true
+	}
+
 	config, err := scheduler_config.Default()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create scheduler config: %v", err)
@@ -65,26 +72,21 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-
 		return nil, fmt.Errorf("couldn't create scheduler framework; %v", err)
 	}
 
+	if startInformer {
+		stopChannel := make(chan struct{})
+		informerFactory.Start(stopChannel)
+		synced := informerFactory.WaitForCacheSync(stopChannel)
+		for k, v := range synced {
+			if !v {
+				return nil, fmt.Errorf("failed to sync informer %v", k)
+			}
+		}
+	}
+
 	checker := &SchedulerBasedPredicateChecker{
 		framework:              framework,
 		delegatingSharedLister: sharedLister,
 	}
-
-	// this MUST be called after all the informers/listers are acquired via the
-	// informerFactory....Lister()/informerFactory....Informer() methods
-	informerFactory.Start(stop)
-
-	// Also wait for all informers to be up-to-date. This is necessary for
-	// objects that were added when creating the fake client. Without
-	// this wait, those objects won't be visible via the informers when
-	// the test runs.
-	synced := informerFactory.WaitForCacheSync(stop)
-	for k, v := range synced {
-		if !v {
-			return nil, fmt.Errorf("failed to sync informer %v", k)
-		}
-	}
-
 	return checker, nil
 }
 

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -60,10 +60,12 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, informe
 	}
 	sharedLister := NewDelegatingSchedulerSharedLister()
 
+	stopChannel := make(chan struct{})
+
 	framework, err := schedulerframeworkruntime.NewFramework(
 		scheduler_plugins.NewInTreeRegistry(),
 		&config.Profiles[0],
-		stop,
+		stopChannel,
 		schedulerframeworkruntime.WithInformerFactory(informerFactory),
 		schedulerframeworkruntime.WithSnapshotSharedLister(sharedLister),
 	)
@@ -73,7 +75,6 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, informe
 	}
 
 	if startInformer {
-		stopChannel := make(chan struct{})
 		informerFactory.Start(stopChannel)
 		synced := informerFactory.WaitForCacheSync(stopChannel)
 		for k, v := range synced {

--- a/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
+++ b/cluster-autoscaler/simulator/scheduler_based_predicates_checker.go
@@ -74,6 +74,17 @@ func NewSchedulerBasedPredicateChecker(kubeClient kube_client.Interface, stop <-
 	// informerFactory....Lister()/informerFactory....Informer() methods
 	informerFactory.Start(stop)
 
+	// Also wait for all informers to be up-to-date. This is necessary for
+	// objects that were added when creating the fake client. Without
+	// this wait, those objects won't be visible via the informers when
+	// the test runs.
+	synced := informerFactory.WaitForCacheSync(stop)
+	for k, v := range synced {
+		if !v {
+			return nil, fmt.Errorf("failed to sync informer %v", k)
+		}
+	}
+
 	return checker, nil
 }
 

--- a/cluster-autoscaler/simulator/test_predicates_checker.go
+++ b/cluster-autoscaler/simulator/test_predicates_checker.go
@@ -23,5 +23,5 @@ import (
 // NewTestPredicateChecker builds test version of PredicateChecker.
 func NewTestPredicateChecker() (PredicateChecker, error) {
 	// just call out to NewSchedulerBasedPredicateChecker but use fake kubeClient
-	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), make(chan struct{}))
+	return NewSchedulerBasedPredicateChecker(clientsetfake.NewSimpleClientset(), nil)
 }

--- a/cluster-autoscaler/utils/replace/replace.go
+++ b/cluster-autoscaler/utils/replace/replace.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replace
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Replacement contains a regular expresssion and a replacement string.
+type Replacement struct {
+	Re          regexp.Regexp
+	Replacement string
+}
+
+func (r Replacement) String() string {
+	// This is intentionally simplistic: we don't bother checking
+	// whether ";" occurs inside the regular expression or the
+	// replacement string.
+	return ";" + r.Re.String() + ";" + r.Replacement + ";"
+}
+
+// Replacements contains multiple regular expressions and their replacements.
+type Replacements []Replacement
+
+var _ flag.Value = &Replacements{}
+
+// ApplyToPair turns a key/value pair into a single <key>=<value> string,
+// applies all regular expressions, then splits again. Key and value
+// may become empty.
+func (r *Replacements) ApplyToPair(k, v string) (string, string) {
+	if r == nil {
+		return k, v
+	}
+	str := k + "=" + v
+	for _, repl := range *r {
+		str = repl.Re.ReplaceAllString(str, repl.Replacement)
+	}
+	parts := strings.SplitN(str, "=", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}
+
+func (r *Replacements) String() string {
+	var parts []string
+	for _, repl := range *r {
+		parts = append(parts, repl.String())
+	}
+	return strings.Join(parts, " ")
+}
+
+const format = "must be of the form <sep><regexp><sep><replacement><sep>"
+
+// Set adds one replacement of the form <sep><regexp><sep><replacement><sep>.
+func (r *Replacements) Set(str string) error {
+	if len(str) < 3 {
+		return errors.New(format + ": too short")
+	}
+	sep := str[0]
+	if str[len(str)-1] != sep {
+		return errors.New(format + ": separator at start and end does not match")
+	}
+	str = str[1 : len(str)-1]
+	parts := strings.Split(str, string(sep))
+	if len(parts) != 2 {
+		return errors.New(format + ": need exactly one separator between regular expression and replacement")
+	}
+	re, err := regexp.Compile(parts[0])
+	if err != nil {
+		return fmt.Errorf("%s: regular expression invalid: %v", format, err)
+	}
+	*r = append(*r, Replacement{Re: *re, Replacement: parts[1]})
+	return nil
+}


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
